### PR TITLE
fix issue of cpslk appearing on different lines in default and raise/…

### DIFF
--- a/keyboards/sofle_pico/keymaps/via/keymap.c
+++ b/keyboards/sofle_pico/keymaps/via/keymap.c
@@ -171,16 +171,16 @@ static void render_status(void) {
     switch (get_highest_layer(layer_state)) {
         case _COLEMAK:
         case _QWERTY:
-            oled_write_P(PSTR("Base\n"), false);
+            oled_write_ln_P(PSTR("Base"), false);
             break;
         case _RAISE:
-            oled_write_P(PSTR("Raise"), false);
+            oled_write_ln_P(PSTR("Raise"), false);
             break;
         case _LOWER:
-            oled_write_P(PSTR("Lower"), false);
+            oled_write_ln_P(PSTR("Lower"), false);
             break;
         case _ADJUST:
-            oled_write_P(PSTR("Adj\n"), false);
+            oled_write_ln_P(PSTR("Adj"), false);
             break;
         default:
             oled_write_ln_P(PSTR("Undef"), false);


### PR DESCRIPTION
Fixed another small bug in the display rendering. The way it was set up inconsistently with newlines and printlns, on the base layer, CPSLK was written one line lower than on raise/lower, leading to doubling of the CPSLK text when in one of those layers. Using oled_write_ln consistently fixes this issue.

Tested it on my board, works.